### PR TITLE
Implement two new sources (data and obj) as well as the existing file source

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -60,23 +60,45 @@ function highlightHelper(text) {
   }
 }
 
+function compileRamlObj(ramlObj, config, onSuccess, onError) {
+    ramlObj = parseBaseUri(ramlObj);
+    ramlObj = traverse(ramlObj);
+
+    // Register handlebar helpers
+    for (var helperName in config.helpers) {
+        handlebars.registerHelper(helperName, config.helpers[helperName]);
+    }
+
+    // Register handlebar partials
+    for (var partialName in config.partials) {
+        handlebars.registerPartial(partialName, config.partials[partialName]);
+    }
+
+    var result = config.template(ramlObj);
+    onSuccess(result);
+}
+
+function parseSource(source, onSuccess, onError) {
+    // Support legacy source argument (using string for filename) as well as object
+    if (typeof(source) === 'string') source = { file: source };
+    source = source || {};
+
+    if (source.file) {
+        raml.loadFile(source.file).then(onSuccess, onError); // parse as file
+    } else if (source.data) {
+        raml.load('' + source.data).then(onSuccess, onError); // parse as string or buffer
+    } else if (source.obj) {
+        process.nextTick(function() {
+            onSuccess(source.obj); // parse RAML object directly
+        });
+    } else {
+        onError(new Error('parseWithConfig: You must supply either file, data or obj as source.'));
+    }
+}
+
 function parseWithConfig(source, config, onSuccess, onError) {
-    raml.loadFile(source).then(function(ramlObj) {
-        ramlObj = parseBaseUri(ramlObj);
-        ramlObj = traverse(ramlObj);
-
-        // Register handlebar helpers
-        for (var helperName in config.helpers) {
-            handlebars.registerHelper(helperName, config.helpers[helperName]);
-        }
-
-        // Register handlebar partials
-        for (var partialName in config.partials) {
-            handlebars.registerPartial(partialName, config.partials[partialName]);
-        }
-
-        var result = config.template(ramlObj);
-        onSuccess(result);
+    parseSource(source, function(ramlObj) {
+        compileRamlObj(ramlObj, config, onSuccess, onError);
     }, onError);
 }
 
@@ -107,7 +129,7 @@ if (require.main === module) {
     }
 
     // Start the parsing process
-    parse(args[0], function(result) {
+    parse({ file: args[0] }, function(result) {
         // For now simply output to console
         process.stdout.write(result);
         process.exit(0);
@@ -119,3 +141,4 @@ if (require.main === module) {
 
 module.exports.parse = parse;
 module.exports.parseWithConfig = parseWithConfig;
+module.exports.parseSource = parseSource;


### PR DESCRIPTION
This fixes #9. Steps taken:
1. Added function parseSource() to take a source (can be a string to be backwards compatible or an object containing either file, data or obj property). It returns the corresponding RAML object.
2. Refactored HTML generation out in its own function compileRamlObj().
3. Updated parseWithConfig() to invoke parseSource() followed by compileRamlObj() with the RAML object.
4. Updated main call to parse() to reflect that source argument now can be an object.
5. Added parseSource() to exported functions.
