### PR TITLE
Adding lock icon for secured resources

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -16,6 +16,7 @@
                     <a href="#" data-toggle="modal" data-target="#{{../uniqueId}}_{{method}}" class="list-group-item">
                         <span class="badge badge_{{method}}">{{method}}</span>
                         {{description}}
+                        {{#if securedBy}}<span class="pull-right"><span class="glyphicon glyphicon-lock" title="Authentication required"></span></span>{{/if}}
                     </a>
                 {{/methods}}
             </div>


### PR DESCRIPTION
Related to issue #10. This is just a simple start. It will take more time to actually parse securitySchemes and display something useful.
