### PR TITLE
Periods in methods break links

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -16,7 +16,7 @@ function parseBaseUri(ramlObj) {
 
 function makeUniqueId(resource) {
     var fullUrl = resource.parentUrl + resource.relativeUri;
-    return fullUrl.replace(/[\{\}\/}]/g, '_');
+    return fullUrl.replace(/[\{\}\/}\.]/g, '_');
 }
 
 function traverse(ramlObj, parentUrl, allUriParameters) {


### PR DESCRIPTION
Something like {id}.json doesn't work. I fixed it by adding period to the list of characters converted to "_" in makeUniqueId(), but not sure if this is valid in the first place as I am new to RAML.
