### PR TITLE
Allow to load external resources via the same Schema

### DIFF
--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -4,10 +4,10 @@
     <title>{{title}} API documentation</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://yandex.st/highlightjs/8.0/styles/github.min.css">
-    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//yandex.st/highlightjs/8.0/styles/github.min.css">
+    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
     <style>
         .parent {


### PR DESCRIPTION
If you publishing a generarated HTML via HTTPS, you get an error because the external resource is ran insecure. This will fix it
