### PR TITLE
close modal through Esc key

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -28,7 +28,7 @@
     </div>
 
     {{#methods}}
-        <div class="modal fade" id="{{../uniqueId}}_{{method}}">
+        <div class="modal fade" tabindex="0" id="{{../uniqueId}}_{{method}}">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">


### PR DESCRIPTION
Currently, Esc key works on Firefox, but not on Chrome and Safari.

Answers under [this SO thread](http://stackoverflow.com/questions/12630156/how-do-you-enable-the-escape-key-close-functionality-in-a-twitter-bootstrap-moda) suggests `tabindex="-1"`.

But [Mozilla doc](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.tabIndex) says that `tabindex` should be positive, so I choose `0`.
