### PR TITLE
Also use code highlighting for documentation pages

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -61,6 +61,13 @@ function _render(ramlObj, config, onSuccess) {
 }
 
 function parseWithConfig(source, config, onSuccess, onError) {
+    
+    if (typeof config.helpers.highlight === 'function' && config.helpers.md === _markDownHelper) {
+        marked.setOptions({
+            highlight: config.helpers.highlight
+        });
+    }
+    
     raml2obj.parse(source, function(ramlObj) {
         ramlObj.config = config;
         ramlObj.config.raml2HtmlVersion = pjson.version;


### PR DESCRIPTION
This commit makes the default markdown parser add missing syntax highlighting to code blocks in documentation content.
