### PR TITLE
Render bootstrap tables

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -8,10 +8,15 @@ var marked = require('marked');
 var program = require('commander');
 var fs = require('fs');
 var pjson = require('../package.json');
+var renderer = new marked.Renderer();
+renderer.table = function(thead, tbody){ 
+    return '<table class="table"><thead>' + thead + '</thead>'
+            + '<tbody>' + tbody + '</tbody></table>'; 
+};
 
 function _markDownHelper(text) {
     if (text && text.length) {
-        return new handlebars.SafeString(marked(text));
+        return new handlebars.SafeString(marked(text, { renderer: renderer }));
     } else {
         return '';
     }


### PR DESCRIPTION
I got a hunch this might not be the place where you'd like this to belong... as it couples the view with the parser. Another approach could be to apply the classes client-side on page load.

However - issue is that tables are not displayed optimal - this way it utilizes the bundled bootstrap table classes. 
