### PR TITLE
Use <div> instead of <a> for list-group-item class.

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -22,11 +22,11 @@
 
             <div class="list-group">
                 {{#methods}}
-                    <a href="#" data-toggle="modal" data-target="#{{../uniqueId}}_{{method}}" class="list-group-item">
+                    <div href="#" data-toggle="modal" data-target="#{{../uniqueId}}_{{method}}" class="list-group-item">
                         <span class="badge badge_{{method}}">{{method}}{{lock securedBy}}</span>
                         <div class="method_description">{{md description}}</div>
                         <div class="clearfix"></div>
-                    </a>
+                    </div>
                 {{/methods}}
             </div>
         </div>


### PR DESCRIPTION
This addresses issue #63 regarding mangled output when the
method description contains a hyperlink.
