### PR TITLE
Adding command line switches to specify custom handlebars templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ As a command line script:
 raml2html example.raml > example.html
 raml2html -i example.raml -o example.html
 raml2html -s -i example.raml -o example.html
+raml2html -t ~/.raml2html/custom-template.handlebars -i example.raml -o example.html
 ```
+
+Find the original *.handlebars files in the `lib` directory of the git repository
+or in your node_modules directory, for example `/usr/local/lib/node_modules/raml2html/lib/`
 
 As a library:
 

--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -74,17 +74,18 @@ function parseWithConfig(source, config, onSuccess, onError) {
     }, onError);
 }
 
-function getDefaultConfig(https) {
+function getDefaultConfig(https, customTemplate, customResource, customItem) {
+
     return {
         'https': https,
-        'template': require('./template.handlebars'),
+        'template': require(customTemplate),
         'helpers': {
             'md': _markDownHelper,
             'lock': _lockIconHelper
         },
         'partials': {
-            'resource': require('./resource.handlebars'),
-            'item': require('./item.handlebars')
+            'resource': require(customResource),
+            'item': require(customItem)
         }
     };
 }
@@ -100,6 +101,9 @@ if (require.main === module) {
         .option('-i, --input [input]', 'RAML input file')
         .option('-s, --https', 'Use https links in the generated output')
         .option('-o, --output [output]', 'HTML output file')
+        .option('-t, --template [template]', 'Path to custom template.harndlebars file')
+        .option('-r, --resource [resource]', 'Path to custom resource.handlebars file')
+        .option('-m, --item [item]', 'Path to custom item.handlebars file')
         .parse(process.argv);
 
     var input = program.input;
@@ -115,9 +119,12 @@ if (require.main === module) {
     }
 
     var https = program.https ? true : false;
+    var customTemplate = program.template ? (program.template.indexOf('.') == 0 ? process.cwd() + "/" + program.template : program.template ) : './template.handlebars';
+    var customResource = program.resource ? (program.resource.indexOf('.') == 0 ? process.cwd() + "/" + program.resource : program.resource ) : './resource.handlebars';
+    var customItem =     program.item ?     (program.item.indexOf('.') == 0 ?     process.cwd() + "/" + program.item : program.item ) :         './item.handlebars';
 
     // Start the parsing process
-    parseWithConfig(input, getDefaultConfig(https), function(result) {
+    parseWithConfig(input, getDefaultConfig(https, customTemplate, customResource, customItem), function(result) {
         if (program.output) {
             fs.writeFileSync(program.output, result);
         } else {


### PR DESCRIPTION
I've added command line options to specify paths to template.handlebars, resource.handlebars, and item.handlebars files. If the specified path begins with a . character, I assume it's a relative path and prepend the cwd. 
