### PR TITLE
Omit resources that have no methods

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -1,3 +1,4 @@
+{{#if methods}}
 <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
@@ -155,7 +156,7 @@
         </div>
     {{/methods}}
 </div>
-
+{{/if}}
 {{#resources}}
     {{> resource}}
 {{/resources}}


### PR DESCRIPTION
Currently resources that have no methods appear in the output
as hot links. When you click on an empty resource, it expands
to reveal that there is no content.

Note: It is possible that one of these empty resources
might have some documentation or a displayName. It would be
better to test for methods or a displayName or a description,
however I couldn't figure out an elegant way to have
handlebars do that.
