### PR TITLE
Show resources if they have a method, displayName, or description

### DIFF
--- a/lib/raml2html.js
+++ b/lib/raml2html.js
@@ -37,6 +37,12 @@ function _lockIconHelper(securedBy) {
     return '';
 }
 
+function _emptyResourceCheckHelper(options) {
+    if(this.methods || this.displayName || this.description){
+	return options.fn(this);
+    }
+}
+
 function render(source, config, onSuccess, onError) {
     config = config || {};
     config.protocol = config.https ? 'https:' : 'http:';
@@ -73,6 +79,7 @@ function getDefaultConfig(https, mainTemplate, resourceTemplate, itemTemplate) {
         'https': https,
         'template': require(mainTemplate || './template.handlebars'),
         'helpers': {
+            'emptyResourceCheck': _emptyResourceCheckHelper,
             'md': _markDownHelper,
             'lock': _lockIconHelper
         },

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -1,4 +1,4 @@
-{{#if methods}}
+{{#emptyResourceCheck}}
     <div class="panel panel-white">
         <div class="panel-heading">
             <h4 class="panel-title">
@@ -156,7 +156,7 @@
             </div>
         {{/methods}}
     </div>
-{{/if}}
+{{/emptyResourceCheck}}
 
 {{#resources}}
     {{> resource}}


### PR DESCRIPTION
A previous fix (#76) omits all resources that do not have
any methods. This change improves on that keeping resources if they
have methods, a displayName, or a description. This allows
for methodless path elements in the api that are used
only for grouping.
