### PR TITLE
Add Details link at the end of method docs in resource view

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -27,7 +27,9 @@
                     {{#methods}}
                         <div data-toggle="modal" data-target="#{{../uniqueId}}_{{method}}" class="list-group-item">
                             <span class="badge badge_{{method}}">{{method}}{{lock securedBy}}</span>
-                            <div class="method_description">{{md description}}</div>
+                            <div class="method_description">{{md description}}
+                                <p class="details"><a href="javascript: void(0)">Details</a>
+			    </div>
                             <div class="clearfix"></div>
                         </div>
                     {{/methods}}

--- a/lib/template.handlebars
+++ b/lib/template.handlebars
@@ -120,6 +120,9 @@
         .method_description p:last-child {
             margin: 0;
         }
+	.details {
+           font-size: smaller;
+	}
     </style>
 </head>
 


### PR DESCRIPTION
Users have mentioned to me that the initially didn't realize
that more documentation is available by clicking on a method
button (or actually anywhere on the expanded method
description). They typically discover this feature on accident.

Longer term, I would suggest a redesign that moves away from
the modal dialogs and incorporates the request and response
tabs in method docs that are revealed by clicking on a resource.

For now, however, a quick fix is to add "Details" link after
each method description. This link does nothing new since
clicking anywhere in the method description div already
opens the modal. However it is formatted as a link and so
provides a hint to the user that they can click it to see
more information.
