### PR TITLE
Expand $ref references so that the HTML doc includes those as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function render(source, config) {
     ramlObj.config = config;
 
     if (config.processRamlObj) {
-      return config.processRamlObj(ramlObj, source).then(function(html) {
+      return config.processRamlObj(ramlObj).then(function(html) {
         if (config.postProcessHtml) {
           return config.postProcessHtml(html);
         }
@@ -49,7 +49,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
   }
 
   return {
-    processRamlObj: function(ramlObj, source) {
+    processRamlObj: function(ramlObj) {
       var nunjucks = require('nunjucks');
       var markdown = require('nunjucks-markdown');
       var marked = require('marked');

--- a/index.js
+++ b/index.js
@@ -22,11 +22,10 @@ function render(source, config) {
     ramlObj.config = config;
 
     if (config.processRamlObj) {
-      return config.processRamlObj(ramlObj).then(function(html) {
+      return config.processRamlObj(ramlObj, source).then(function(html) {
         if (config.postProcessHtml) {
           return config.postProcessHtml(html);
         }
-
         return html;
       });
     }
@@ -50,10 +49,11 @@ function getDefaultConfig(mainTemplate, templatesPath) {
   }
 
   return {
-    processRamlObj: function(ramlObj) {
+    processRamlObj: function(ramlObj, source) {
       var nunjucks = require('nunjucks');
       var markdown = require('nunjucks-markdown');
       var marked = require('marked');
+      var ramljsonexpander = require('raml-jsonschema-expander');
       var renderer = new marked.Renderer();
       renderer.table = function(thead, tbody) {
         // Render Bootstrap style tables
@@ -70,6 +70,9 @@ function getDefaultConfig(mainTemplate, templatesPath) {
       ramlObj.securitySchemeWithName = function(name) {
         return ramlObj.securitySchemes[0][name];
       };
+
+      // Find and replace the $ref parameters.
+      ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj, source);
 
       // Render the main template using the raml object and fix the double quotes
       var html = env.render(mainTemplate, ramlObj);

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
       };
 
       // Find and replace the $ref parameters.
-      ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj, source);
+      ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj);
 
       // Render the main template using the raml object and fix the double quotes
       var html = env.render(mainTemplate, ramlObj);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "nunjucks": "1.3.x",
     "nunjucks-markdown": "1.0.x",
     "q": "1.4.x",
-    "raml2obj": "2.2.x"
+    "raml2obj": "2.2.x",
+    "raml-jsonschema-expander": "1.0.2"
   },
   "devDependencies": {
     "eslint": "1.2.x",


### PR DESCRIPTION
This allows us to work with reusable JSON Schemas and still benefit from the RAML2HTML documentation.

Simple dependency that is added, huge benefit!