### PR TITLE
Adding security information to the HTML output

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       // Add extra function for finding a security scheme by name
       ramlObj.securitySchemeWithName = function(name) {
-        return ramlObj.securitySchemes[0][name];
+        for (index = 0; index < ramlObj.securitySchemes.length; ++index) {
+          if (ramlObj.securitySchemes[index][name] != null) {
+            return ramlObj.securitySchemes[index][name]
+          }
+        }
       };
 
       // Render the main template using the raml object and fix the double quotes

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -187,7 +187,7 @@
 
                 {% if method.securedBy.length %}
                   <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
-                    {% set securityScheme = securitySchemeWithName(securedBy) %}
+                    {% set securityScheme = securitySchemeWithName(method.securedBy) %}
                     Secured by {{ method.securedBy }}
 
                     {% if securityScheme.describedBy.headers %}

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -190,6 +190,15 @@
                     {% set securityScheme = securitySchemeWithName(securedBy) %}
                     Secured by {{ method.securedBy }}
 
+                    {% if securityScheme.describedBy.headers %}
+                      <h3>Headers</h3>
+                      <ul>
+                        {% for key, item in securityScheme.describedBy.headers %}
+                          {% include "./item.nunjucks" %}
+                        {% endfor %}
+                      </ul>
+                    {% endif %}
+
                     {% for key, response in securityScheme.describedBy.responses %}
                       <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
                       {% markdown %}{{ response.description}}{% endmarkdown %}
@@ -201,23 +210,6 @@
                             {% include "./item.nunjucks" %}
                           {% endfor %}
                         </ul>
-                      {% endif %}
-
-                      {% if response.body %}
-                        <h3>Body</h3>
-                        {% for key, b in response.body %}
-                          <p><strong>Type: {{ key }}</strong></p>
-
-                          {% if b.schema %}
-                            <p><strong>Schema</strong>:</p>
-                            <pre><code>{{ b.schema | escape }}</code></pre>
-                          {% endif %}
-
-                          {% if b.example %}
-                            <p><strong>Example</strong>:</p>
-                            <pre><code>{{ b.example | escape }}</code></pre>
-                          {% endif %}
-                        {% endfor %}
                       {% endif %}
                     {% endfor %}
 

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -84,6 +84,12 @@
                     <a href="#{{ resource.uniqueId }}_{{ method.method }}_response" data-toggle="tab">Response</a>
                   </li>
                 {% endif %}
+
+                {% if method.securedBy.length %}
+                  <li class="active">
+                    <a href="#{{ resource.uniqueId }}_{{ method.method }}_securedby" data-toggle="tab">Security</a>
+                  </li>
+                {% endif %}
               </ul>
 
               <!-- Tab panes -->
@@ -176,6 +182,45 @@
                         {% endfor %}
                       {% endif %}
                     {% endfor %}
+                  </div>
+                {% endif %}
+
+                {% if method.securedBy.length %}
+                  <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
+                    {% set securityScheme = securitySchemeWithName(securedBy) %}
+                    Secured by {{ method.securedBy }}
+
+                    {% for key, response in securityScheme.describedBy.responses %}
+                      <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
+                      {% markdown %}{{ response.description}}{% endmarkdown %}
+
+                      {% if response.headers %}
+                        <h3>Headers</h3>
+                        <ul>
+                          {% for key, item in response.headers %}
+                            {% include "./item.nunjucks" %}
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+
+                      {% if response.body %}
+                        <h3>Body</h3>
+                        {% for key, b in response.body %}
+                          <p><strong>Type: {{ key }}</strong></p>
+
+                          {% if b.schema %}
+                            <p><strong>Schema</strong>:</p>
+                            <pre><code>{{ b.schema | escape }}</code></pre>
+                          {% endif %}
+
+                          {% if b.example %}
+                            <p><strong>Example</strong>:</p>
+                            <pre><code>{{ b.example | escape }}</code></pre>
+                          {% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    {% endfor %}
+
                   </div>
                 {% endif %}
               </div>

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -86,7 +86,7 @@
                 {% endif %}
 
                 {% if method.securedBy.length %}
-                  <li class="active">
+                  <li>
                     <a href="#{{ resource.uniqueId }}_{{ method.method }}_securedby" data-toggle="tab">Security</a>
                   </li>
                 {% endif %}


### PR DESCRIPTION
In response to #160, here's a fix to parse the details of the security schema. In my local test this led to the following result:

![security_ramlhtml](https://cloud.githubusercontent.com/assets/161341/11929641/455e9faa-a7dd-11e5-8ee8-979bdef7f20d.png)
