### PR TITLE
Add support for securedBy scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,15 +79,15 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
-        if(typeof securedBy === 'object'){
+        if (typeof securedBy === 'object'){
           var out = "";
-          for (key in securedBy){
+          for (key in securedBy) {
             out += "<b>" + key + "</b>";
-            if(securedBy[key].scopes){
+            if (securedBy[key].scopes) {
               out += " with scopes:<ul>";
-              for (var i = securedBy[key].scopes.length - 1; i >= 0; i--) {
-                out += "<li>" + securedBy[key].scopes[i] + "</li>";
-              };
+              for (var index = 0; index < securedBy[key].scopes.length; ++index) {
+                out += "<li>" + securedBy[key].scopes[index] + "</li>";
+              }
               out += "</ul>";
             }
           }

--- a/index.js
+++ b/index.js
@@ -80,15 +80,15 @@ function getDefaultConfig(mainTemplate, templatesPath) {
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
         if (typeof securedBy === 'object') {
-          var out = "";
+          var out = '';
           for (key in securedBy) {
-            out += "<b>" + key + "</b>";
+            out += '<b>' + key + '</b>';
             if (securedBy[key].scopes) {
-              out += " with scopes:<ul>";
+              out += ' with scopes:<ul>';
               for (var index = 0; index < securedBy[key].scopes.length; ++index) {
-                out += "<li>" + securedBy[key].scopes[index] + "</li>";
+                out += '<li>' + securedBy[key].scopes[index] + '</li>';
               }
-              out += "</ul>";
+              out += '</ul>';
             }
           }
           return out;

--- a/index.js
+++ b/index.js
@@ -79,22 +79,24 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
+        var out = '';
         if (typeof securedBy === 'object') {
-          var out = '';
-          for (key in securedBy) {
-            out += '<b>' + key + '</b>';
-            if (securedBy[key].scopes) {
-              out += ' with scopes:<ul>';
-              for (var index = 0; index < securedBy[key].scopes.length; ++index) {
-                out += '<li>' + securedBy[key].scopes[index] + '</li>';
+          for (var key in securedBy) {
+            if (securedBy.hasOwnProperty(key)) {
+              out += '<b>' + key + '</b>';
+              if (securedBy[key].scopes.length) {
+                out += ' with scopes:<ul>';
+                for (var index = 0; index < securedBy[key].scopes.length; ++index) {
+                  out += '<li>' + securedBy[key].scopes[index] + '</li>';
+                }
+                out += '</ul>';
               }
-              out += '</ul>';
             }
           }
-          return out;
         } else {
-          return securedBy;
-        } 
+          out = securedBy;
+        }
+        return out;
       };
 
       // Find and replace the $ref parameters.

--- a/index.js
+++ b/index.js
@@ -77,6 +77,26 @@ function getDefaultConfig(mainTemplate, templatesPath) {
         }
       };
 
+      // Parse securedBy and use scopes if they are defined
+      ramlObj.renderSecuredBy = function (securedBy) {
+        if(typeof securedBy === 'object'){
+          var out = "";
+          for (key in securedBy){
+            out += "<b>" + key + "</b>";
+            if(securedBy[key].scopes){
+              out += " with scopes:<ul>";
+              for (var i = securedBy[key].scopes.length - 1; i >= 0; i--) {
+                out += "<li>" + securedBy[key].scopes[i] + "</li>";
+              };
+              out += "</ul>";
+            }
+          }
+          return out;
+        } else {
+          return securedBy;
+        } 
+      };
+
       // Find and replace the $ref parameters.
       ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj);
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
             }
           }
         } else {
-          out = securedBy;
+          out = '<b>' + securedBy + '</b>';
         }
         return out;
       };

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
-        if (typeof securedBy === 'object'){
+        if (typeof securedBy === 'object') {
           var out = "";
           for (key in securedBy) {
             out += "<b>" + key + "</b>";

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -62,7 +62,8 @@
               {% if method.securedBy.length %}
                 {% for securedBy in method.securedBy %}
                   <div class="alert alert-warning">
-                    <span class="glyphicon glyphicon-lock" title="Authentication required"></span> Secured by {{ securedBy }}
+                    {% set securedByScopes = renderSecuredBy(securedBy) %}
+                    <span class="glyphicon glyphicon-lock" title="Authentication required"></span> Secured by {{ securedByScopes }}
                     {% set securityScheme = securitySchemeWithName(securedBy) %}
                     {% if securityScheme.description %}
                       {% markdown %}{{ securityScheme.description }}{% endmarkdown %}


### PR DESCRIPTION
In response to #165 and #10 

Before:
![image](https://cloud.githubusercontent.com/assets/6028967/13809671/ecf61934-ebbf-11e5-9abf-db3ef77c101d.png)


After:
![image](https://cloud.githubusercontent.com/assets/6028967/13809676/f6251c30-ebbf-11e5-9108-8cdeed55931b.png)


If you are happy with my approach, I can implement the same for the security tab also, as this is how it currently looks for me:
![image](https://cloud.githubusercontent.com/assets/6028967/13809733/3a4d9a18-ebc0-11e5-9b47-2fae9345942c.png)


Here is what my securedBy property looks like: 
```
securedBy: [ oauth_2_0: { scopes: [ Report_Viewers, Report_Analysts, Power_Users, Data_Engineers, Administrators ] } ]
```