### PR TITLE
Allow a fakeroot to be added so the reference expander can find the json schemas if they are local

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -12,6 +12,7 @@ program
   .usage('[options] [RAML input file]')
   .option('-i, --input [input]', 'RAML input file')
   .option('-t, --template [template]', 'Filename of the custom Nunjucks template')
+  .option('-f, --fakeroot [fakeroot]', 'Path to where the JSON Schema is stored if not online. Eg ../raml/schemas/')
   .option('-o, --output [output]', 'HTML output file')
   .parse(process.argv);
 
@@ -28,7 +29,7 @@ if (!input) {
 }
 
 // Start the rendering process
-raml2html.render(input, raml2html.getDefaultConfig(program.template)).then(function(result) {
+raml2html.render(input, raml2html.getDefaultConfig(program.template, "", program.fakeroot)).then(function(result) {
   if (program.output) {
     fs.writeFileSync(program.output, result);
   } else {

--- a/index.js
+++ b/index.js
@@ -39,15 +39,19 @@ function render(source, config) {
 /**
  * @param {String} [mainTemplate] - The filename of the main template, leave empty to use default templates
  * @param {String} [templatesPath] - Optional, by default it uses the current working directory
+ * @param {String} [fakeRoot] - Optional, a fake root directory to append to the json schema files.
  * @returns {{processRamlObj: Function, postProcessHtml: Function}}
  */
-function getDefaultConfig(mainTemplate, templatesPath) {
+function getDefaultConfig(mainTemplate, templatesPath, fakeRoot) {
   if (!mainTemplate) {
     mainTemplate = './lib/template.nunjucks';
 
     // When using the default template, make sure that Nunjucks isn't
     // using the working directory since that might be anything
     templatesPath = __dirname;
+  }
+  if (!fakeRoot) {
+    fakeRoot = ""
   }
 
   return {
@@ -100,7 +104,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
       };
 
       // Find and replace the $ref parameters.
-      ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj);
+      ramlObj = ramljsonexpander.expandJsonSchemas(ramlObj, fakeRoot);
 
       // Render the main template using the raml object and fix the double quotes
       var html = env.render(mainTemplate, ramlObj);


### PR DESCRIPTION
Allow a fakeroot to be given so that json schemas that need to be expanded can use the correct root such as a local path or even an url.

Example:
~/myapi/doc$ node_modules/raml2html/bin/raml2html raml/api.raml -o index.html -f "raml/api/schemas"

so my json schemas live in /myapi/doc/raml/api/schemas. I could also say:

~/myapi/doc$ node_modules/raml2html/bin/raml2html raml/api.raml -o index.html -f "http://localhost:9000" if I want them to be prefixed with that url.