### PR TITLE
Fixing security tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,17 @@ function getDefaultConfig(mainTemplate, templatesPath) {
         }
       };
 
+      // Add extra function for finding a security scheme name
+      ramlObj.securitySchemeName = function (name) {
+        for (var index = 0; index < ramlObj.securitySchemes.length; ++index) {
+          if (ramlObj.securitySchemes[index][name] !== null) {
+            var keys = Object.keys(ramlObj.securitySchemes[index]);
+            return keys[0];
+          }
+        }
+        return name;
+      };
+
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
         var out = '';

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -204,6 +204,11 @@
                       {% set securityScheme = securitySchemeWithName(securitySchemeName) %}
 
                       Secured by {{ securedByScopes }}
+                      
+                      {% if securityScheme.description %}
+                        <h3>Description</h3>
+                        {% markdown %}{{ securityScheme.description }}{% endmarkdown %}
+                      {% endif %}
 
                       {% if securityScheme.describedBy.headers %}
                         <h3>Headers</h3>

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -197,34 +197,38 @@
                 {% endif %}
 
                 {% if method.securedBy.length %}
-                  <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
-                    {% set securityScheme = securitySchemeWithName(method.securedBy) %}
-                    Secured by {{ method.securedBy }}
+                  {% for securedBy in method.securedBy %}
+                    <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
+                      {% set securitySchemeName = securitySchemeName(securedBy) %}
+                      {% set securedByScopes = renderSecuredBy(securedBy) %}
+                      {% set securityScheme = securitySchemeWithName(securitySchemeName) %}
 
-                    {% if securityScheme.describedBy.headers %}
-                      <h3>Headers</h3>
-                      <ul>
-                        {% for key, item in securityScheme.describedBy.headers %}
-                          {% include "./item.nunjucks" %}
-                        {% endfor %}
-                      </ul>
-                    {% endif %}
+                      Secured by {{ securedByScopes }}
 
-                    {% for key, response in securityScheme.describedBy.responses %}
-                      <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
-                      {% markdown %}{{ response.description}}{% endmarkdown %}
-
-                      {% if response.headers %}
+                      {% if securityScheme.describedBy.headers %}
                         <h3>Headers</h3>
                         <ul>
-                          {% for key, item in response.headers %}
+                          {% for key, item in securityScheme.describedBy.headers %}
                             {% include "./item.nunjucks" %}
                           {% endfor %}
                         </ul>
                       {% endif %}
-                    {% endfor %}
 
-                  </div>
+                      {% for key, response in securityScheme.describedBy.responses %}
+                        <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
+                        {% markdown %}{{ response.description}}{% endmarkdown %}
+
+                        {% if response.headers %}
+                          <h3>Headers</h3>
+                          <ul>
+                            {% for key, item in response.headers %}
+                              {% include "./item.nunjucks" %}
+                            {% endfor %}
+                          </ul>
+                        {% endif %}
+                      {% endfor %}
+                    </div>
+                  {% endfor %}
                 {% endif %}
               </div>
             </div>


### PR DESCRIPTION
Currently the security tab for a resource is broken as it does not list the security properties if scopes are defined. I tested it with and without scopes and this seems to fix it. Happy to provide more details.