### PR TITLE
fixed issue with differences between 0.8 and 1.0 

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,16 +84,25 @@ function getDefaultConfig(mainTemplate, templatesPath) {
        * Scalars: 'string', 'number', 'integer', 'boolean', 'date', 'file', 'scalar'
        */
       ramlObj.getRootType = function (type) {
+        // in 0.8 the type node was not an array, that changed in 1.0
+        if( typeof type.type === 'string' ) {
+          type.type = [ type.type ];
+        }
+
         if (type.type.length > 1) {
           // Multiple inheritence is only supported for object types.
           return 'object';
         }
-        var parent = type.type[0];
-        for (var index = 0; index < ramlObj.types.length; ++index) {
-          if (typeof ramlObj.types[index][parent] !== 'undefined') {
-            return ramlObj.getRootType(ramlObj.types[index][parent]);
+
+        if(ramlObj.types) {
+          var parent = type.type[0];
+          for (var index = 0; index < ramlObj.types.length; ++index) {
+            if (typeof ramlObj.types[index][parent] !== 'undefined') {
+              return ramlObj.getRootType(ramlObj.types[index][parent]);
+            }
           }
         }
+        
         return type.type[0];
       };
 


### PR DESCRIPTION
that is with regards to non-arrays vs arrays respectively. this PR will fix #202. It actually fixes two things: 

* in 0.8 the the type node was a single item not an array (that is covered [here](https://github.com/raml2html/raml2html/blob/260cef924f1b4450765d08fb6fbb870e65f77aa6/index.js#L88) now)
* if there is no root `types` declaration, the function `getRootType` should not try to find types there (covered [here](https://github.com/raml2html/raml2html/blob/260cef924f1b4450765d08fb6fbb870e65f77aa6/index.js#L97))

