### PR TITLE
Convert README.md to Github flavored Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ raml2html -t examples/custom-template-test/template.nunjucks -i example.raml -o 
 ### As a library
 
 #### Using the default templates or your own Nunjucks templates
-```
+```javascript
 var raml2html = require('raml2html');
 var configWithDefaultTemplates = raml2html.getDefaultConfig();
 var configWithCustomTemplates = raml2html.getDefaultConfig('my-custom-template.nunjucks', __dirname);
@@ -40,7 +40,7 @@ raml2html.render(source, configWithDefaultTemplates).then(function(result) {
 ```
 
 #### Using your own processing function, for when you want to use another template language
-```
+```javascript
 /**
  * config should be an object with at least an `processRamlObj` property which is a function that receives the raw RAML 
  * object and must return a promise with the result. You can do whatever you want in this function.


### PR DESCRIPTION
Going to [Github Flavored Markdown](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown), resulting nice syntax colored code blocks