### PR TITLE
Fix bug of show `[object Object]` in Example

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var raml2obj = require('raml2obj');
 var pjson = require('./package.json');
 var Q = require('q');
+var yaml = require('js-yaml');
 
 /**
  * Render the source RAML object using the config's processOutput function
@@ -192,6 +193,10 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       ramlObj.isArray = function (value) {
         return Array.isArray(value);
+      };
+
+      ramlObj.stringify = function (value) {
+        return typeof value === 'object' ? yaml.dump(value) : value;
       };
 
       // Find and replace the $ref parameters.

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -166,7 +166,7 @@
 
                         {% if b.example %}
                           <p><strong>Example</strong>:</p>
-                          <pre><code>{{ b.example | escape }}</code></pre>
+                          <pre><code>{{ stringify(b.example) | escape }}</code></pre>
                         {% endif %}
                       {% endfor %}
                     {% endif %}
@@ -229,7 +229,7 @@
 
                           {% if b.example %}
                             <p><strong>Example</strong>:</p>
-                            <pre><code>{{ b.example | escape }}</code></pre>
+                            <pre><code>{{ stringify(b.example) | escape }}</code></pre>
                           {% endif %}
                         {% endfor %}
                       {% endif %}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "commander": "2.9.x",
     "marked": "0.3.x",
+    "js-yaml": "^3.6.1",
     "minimize": "1.8.x",
     "nunjucks": "1.3.x",
     "nunjucks-markdown": "1.0.x",


### PR DESCRIPTION
In `raml1.0` branch, I write a JSON string in `example` field, but it will show `[object Object]`.

### Problem

```raml
/box:
  get:
    responses:
      200:
        body:
          application/json:
            example: |
              {}
```

to

![2016-05-25 8 24 13](https://cloud.githubusercontent.com/assets/3001525/15539729/b6818428-22b6-11e6-96ec-eb0690aad7c6.png)