### PR TITLE
fix #212: log full error to console

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -37,6 +37,6 @@ raml2html.render(input, raml2html.getDefaultConfig(program.template)).then(funct
     process.exit(0);
   }
 }).catch(function(error) {
-  console.error(new Error(error));
+  console.error(error);
   process.exit(1);
 });


### PR DESCRIPTION
Fixes https://github.com/raml2html/raml2html/issues/212

Was:
```
[Error: Error: Api contains errors.]
```

Now:
```
{ [Error: Api contains errors.]
  parserErrors: 
   [ { code: 2,
       message: 'Unknown node: xxx',
       path: 'foo.raml',
       start: 28,
       end: 31,
       line: 2,
       column: 0,
       range: [Object],
       isWarning: false } ] }
```

