### PR TITLE
upgrade nunjucks and fix template

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
       };
 
       // Setup the Nunjucks environment with the markdown parser
-      const env = nunjucks.configure(templatesPath, { watch: false });
+      const env = nunjucks.configure(templatesPath, { autoescape: false });
       markdown.register(env, (md) => marked(md, { renderer }));
 
       // Add extra function for finding a security scheme by name

--- a/lib/item.nunjucks
+++ b/lib/item.nunjucks
@@ -27,7 +27,9 @@
     )
   </em>
 
-  {% markdown %}{{ item.description }}{% endmarkdown %}
+{% markdown %}
+{{ item.description }}
+{% endmarkdown %}
 
   {% if item.schema %}
     <p><strong>Schema</strong>:</p>

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -21,7 +21,9 @@
         {% if resource.parentUrl %}
           {% if resource.description %}
             <div class="resource-description">
-              {% markdown %}{{ resource.description }}{% endmarkdown %}
+{% markdown %}
+{{ resource.description }}
+{% endmarkdown %}
             </div>
           {% endif %}
         {% endif %}
@@ -31,7 +33,9 @@
             <div onclick="window.location.href = '#{{ resource.uniqueId }}_{{ method.method }}'" class="list-group-item">
               <span class="badge badge_{{ method.method }}">{{ method.method }}{% if method.securedBy.length %} <span class="glyphicon glyphicon-lock" title="Authentication required"></span>{% endif %}</span>
               <div class="method_description">
-                {% markdown %}{{ method.description}}{% endmarkdown %}
+{% markdown %}
+{{ method.description}}
+{% endmarkdown %}
               </div>
               <div class="clearfix"></div>
             </div>
@@ -55,7 +59,9 @@
             <div class="modal-body">
               {% if method.description %}
                 <div class="alert alert-info">
-                  {% markdown %}{{ method.description}}{% endmarkdown %}
+{% markdown %}
+{{ method.description}}
+{% endmarkdown %}
                 </div>
               {% endif %}
 
@@ -66,7 +72,9 @@
                     <span class="glyphicon glyphicon-lock" title="Authentication required"></span> Secured by {{ securedByScopes }}
                     {% set securityScheme = securitySchemeWithName(securedBy) %}
                     {% if securityScheme.description %}
-                      {% markdown %}{{ securityScheme.description }}{% endmarkdown %}
+{% markdown %}
+{{ securityScheme.description }}
+{% endmarkdown %}
                     {% endif %}
                   </div>
                 {% endfor %}
@@ -165,7 +173,9 @@
                     %}" id="{{ resource.uniqueId }}_{{ method.method }}_response">
                     {% for key, response in method.responses %}
                       <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
-                      {% markdown %}{{ response.description}}{% endmarkdown %}
+{% markdown %}
+{{ response.description}}
+{% endmarkdown %}
 
                       {% if response.headers %}
                         <h3>Headers</h3>
@@ -213,8 +223,9 @@
 
                       {% for key, response in securityScheme.describedBy.responses %}
                         <h2>HTTP status code <a href="http://httpstatus.es/{{ key }}" target="_blank">{{ key }}</a></h2>
-                        {% markdown %}{{ response.description}}{% endmarkdown %}
-
+{% markdown %}
+{{ response.description}}
+{% endmarkdown %}
                         {% if response.headers %}
                           <h3>Headers</h3>
                           <ul>

--- a/lib/template.nunjucks
+++ b/lib/template.nunjucks
@@ -180,7 +180,9 @@
 
             {% for chapter in documentation %}
               <h3 id="{{ chapter.uniqueId }}"><a href="#{{ chapter.uniqueId }}">{{ chapter.title }}</a></h3>
-              {% markdown %}{{ chapter.content }}{% endmarkdown %}
+{% markdown %}
+{{ chapter.content }}
+{% endmarkdown %}
             {% endfor %}
           </div>
 
@@ -193,7 +195,9 @@
               <div class="panel-body">
                 {% if resource.description %}
                   <div class="top-resource-description">
-                    {% markdown %}{{ resource.description }}{% endmarkdown %}
+{% markdown %}
+{{ resource.description }}
+{% endmarkdown %}
                   </div>
                 {% endif %}
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "commander": "2.9.x",
     "marked": "0.3.x",
     "minimize": "1.8.x",
-    "nunjucks": "1.3.x",
-    "nunjucks-markdown": "1.0.x",
+    "nunjucks": "2.4.x",
+    "nunjucks-markdown": "2.0.x",
     "raml2obj": "2.2.x",
     "raml-jsonschema-expander": "1.1.x"
   },


### PR DESCRIPTION
- old version of nunjucks depends on old version of fsevents via
  chokidar, which does not work on node 6.x. See
  https://github.com/strongloop/fsevents/pull/128

- nunjucks-markdown expect blocks at the same level with {% markdown %}
  tag. So fix the template.