### PR TITLE
Fix for #232

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
             }
           }
         }
-        
+
         return type.type[0];
       };
 
@@ -128,9 +128,11 @@ function getDefaultConfig(mainTemplate, templatesPath) {
         if (nameStr.endsWith('[]')) {
           name = nameStr.slice(0, -2);
         }
-        for (var index = 0; index < ramlObj.types.length; ++index) {
-          if (typeof ramlObj.types[index][name] !== 'undefined') {
-            return ramlObj.types[index][name];
+        if(ramlObj.types) {
+          for (var index = 0; index < ramlObj.types.length; ++index) {
+            if (typeof ramlObj.types[index][name] !== 'undefined') {
+              return ramlObj.types[index][name];
+            }
           }
         }
       };


### PR DESCRIPTION
Checking if ramlObj.types exists before accessing its property length.