### PR TITLE
Make JSON Schema and example blocks collapsable

### DIFF
--- a/lib/item.nunjucks
+++ b/lib/item.nunjucks
@@ -30,16 +30,20 @@
   {% markdown %}{{ item.description }}{% endmarkdown %}
 
   {% if item.schema %}
-    <p><strong>Schema</strong>:</p>
-    <pre><code>{{ item.schema | escape }}</code></pre>
+    <div>
+      <p><strong>Schema</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+      <pre style="display: none"><code>{{ item.schema | escape }}</code></pre>
+    </div>
   {% endif %}
 
   {% if item.example %}
-    <p><strong>Example</strong>:</p>
-    {% if item.type == 'string' %}
-      <pre>{{ item.example| escape }}</pre>
-    {% else %}
-      <pre><code>{{ item.example | escape }}</code></pre>
-    {% endif %}
+    <div>
+      <p><strong>Example</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+      {% if item.type == 'string' %}
+        <pre style="display: none">{{ item.example| escape }}</pre>
+      {% else %}
+        <pre style="display: none"><code>{{ item.example | escape }}</code></pre>
+      {% endif %}
+    </div>
   {% endif %}
 </li>

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -143,13 +143,17 @@
                         {% endif %}
 
                         {% if b.schema %}
-                          <p><strong>Schema</strong>:</p>
-                          <pre><code>{{ b.schema | escape }}</code></pre>
+                          <div>
+                            <p><strong>Schema</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+                            <pre style="display: none"><code>{{ b.schema | escape }}</code></pre>
+                          </div>
                         {% endif %}
 
                         {% if b.example %}
-                          <p><strong>Example</strong>:</p>
-                          <pre><code>{{ b.example | escape }}</code></pre>
+                          <div>
+                            <p><strong>Example</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+                            <pre style="display: none"><code>{{ b.example | escape }}</code></pre>
+                          </div>
                         {% endif %}
                       {% endfor %}
                     {% endif %}
@@ -182,13 +186,17 @@
                           <p><strong>Type: {{ key }}</strong></p>
 
                           {% if b.schema %}
-                            <p><strong>Schema</strong>:</p>
-                            <pre><code>{{ b.schema | escape }}</code></pre>
+                            <div>
+                              <p><strong>Schema</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+                              <pre style="display: none"><code>{{ b.schema | escape }}</code></pre>
+                            </div>
                           {% endif %}
 
                           {% if b.example %}
-                            <p><strong>Example</strong>:</p>
-                            <pre><code>{{ b.example | escape }}</code></pre>
+                            <div>
+                              <p><strong>Example</strong>: <a href="#" class="btn btn-xs btn-default toggle-schema-or-example">Show</a></p>
+                              <pre style="display: none"><code>{{ b.example | escape }}</code></pre>
+                            </div>
                           {% endif %}
                         {% endfor %}
                       {% endif %}

--- a/lib/template.nunjucks
+++ b/lib/template.nunjucks
@@ -47,6 +47,24 @@
             }
           } catch(e) {}
         });
+
+        // allow to show/hide JSON shemas or examples
+        $('.toggle-schema-or-example').on('click', function(e) {
+            e.preventDefault();
+
+            var self = $(this);
+
+            self.parent().siblings('pre').slideToggle({
+                easing: 'linear',
+                complete: function() {
+                    if ($(this).is(':visible')) {
+                        self.text('Hide');
+                    } else {
+                        self.text('Show');
+                    }
+                }
+            });
+        });
       });
     </script>
 


### PR DESCRIPTION
Because they are often big.

![image](https://cloud.githubusercontent.com/assets/2053431/17521158/9e208d16-5e52-11e6-87e7-9ce764ebfc35.png)
