### PR TITLE
Fix examples not showing in documentation

### DIFF
--- a/lib/item.nunjucks
+++ b/lib/item.nunjucks
@@ -41,7 +41,7 @@
     {% if item.type == 'string' %}
       <pre>{{ item.example| escape }}</pre>
     {% else %}
-      <pre><code>{{ item.example | escape }}</code></pre>
+      <pre><code>{{ item.structuredExample.value | escape }}</code></pre>
     {% endif %}
   {% endif %}
 </li>

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -159,7 +159,7 @@
 
                         {% if b.example %}
                           <p><strong>Example</strong>:</p>
-                          <pre><code>{{ b.example | escape }}</code></pre>
+                          <pre><code>{{ b.structuredExample.value | escape }}</code></pre>
                         {% endif %}
                       {% endfor %}
                     {% endif %}
@@ -200,7 +200,7 @@
 
                           {% if b.example %}
                             <p><strong>Example</strong>:</p>
-                            <pre><code>{{ b.example | escape }}</code></pre>
+                            <pre><code>{{ b.structuredExample.value | escape }}</code></pre>
                           {% endif %}
                         {% endfor %}
                       {% endif %}


### PR DESCRIPTION
This fixes YAML structured examples not showing in the generated documentation. I'm not intimate with the tool to be sure this is a good fix but should point to the right direction.