### PR TITLE
raml2html as a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:onbuild
+RUN mkdir -p /data
+VOLUME /data
+WORKDIR /data
+ENV PATH /usr/src/app/bin:$PATH
+ENTRYPOINT ["/usr/src/app/bin/raml2html"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ raml2html example.raml > example.html
 raml2html -t examples/custom-template-test/template.nunjucks -i example.raml -o example.html
 ```
 
+### As a Docker container
+```
+docker run --rm -v "$PWD":/data raml2html/raml2html --help
+docker run --rm -v "$PWD":/data raml2html/raml2html example.raml > example.html
+docker run --rm -v "$PWD":/data raml2html/raml2html -t examples/custom-template-test/template.nunjucks -i example.raml -o example.html
+```
+
 ### As a library
 
 #### Using the default templates or your own Nunjucks templates


### PR DESCRIPTION
I've created [an organization on Docker Hub](https://hub.docker.com/u/raml2html/) and pushed the first version of [raml2html 3.0.0 image](https://hub.docker.com/r/raml2html/raml2html/tags/). If you're interested in merging it, I can transfer the ownership to you and describe how to build images when the new version is released.