### PR TITLE
proposal: command line flag to override baseUri in html output

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -10,6 +10,7 @@ const pjson = require('../package.json');
 program
   .version(pjson.version)
   .usage('[options] [RAML input file]')
+  .option('--base-uri [uri]', 'Override the RAML-specified baseUri in the HTML otuput')
   .option('-i, --input [input]', 'RAML input file')
   .option('-t, --template [template]', 'Filename of the custom Nunjucks template')
   .option('-o, --output [output]', 'HTML output file')
@@ -27,8 +28,12 @@ if (!input) {
   input = program.args[0];
 }
 
+const opts = {
+  baseUri: program.baseUri
+}
+
 // Start the rendering process
-raml2html.render(input, raml2html.getDefaultConfig(program.template)).then((result) => {
+raml2html.render(input, raml2html.getDefaultConfig(program.template), opts).then((result) => {
   if (program.output) {
     fs.writeFileSync(program.output, result);
   } else {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const Minimize = require('minimize');
  * @param {Function} config.processRamlObj
  * @returns a promise
  */
-function render(source, config) {
+function render(source, config, opts = {}) {
   config = config || {};
   config.raml2HtmlVersion = pjson.version;
 
@@ -26,7 +26,7 @@ function render(source, config) {
     ramlObj.config = config;
 
     if (config.processRamlObj) {
-      return config.processRamlObj(ramlObj, config).then((html) => {
+      return config.processRamlObj(ramlObj, config, opts).then((html) => {
         if (config.postProcessHtml) {
           return config.postProcessHtml(html);
         }
@@ -53,7 +53,9 @@ function getDefaultConfig(mainTemplate, templatesPath) {
   }
 
   return {
-    processRamlObj(ramlObj, config) {
+    processRamlObj(ramlObj, config, opts) {
+      if (opts.baseUri) ramlObj.baseUri = opts.baseUri
+
       const renderer = new marked.Renderer();
       renderer.table = function (thead, tbody) {
         // Render Bootstrap style tables


### PR DESCRIPTION
Hi, I'm loving the work with RAML 1.0 and beta 5 is working great! (after commenting out type: lines)

I'm about to integrate building the documentation into my deploy script, and I was thinking it would be nice to override the baseUri for my staging environment

Really, all this does is change the URL at the top of the HTML. I could probably do the same thing with sed. But I thought I'd submit this PR in case it's interesting

Let me know if this is something you're interested in merging and/or if I should make any changes