### PR TITLE
Fix template typo that stops rendering of type properties

### DIFF
--- a/lib/item.nunjucks
+++ b/lib/item.nunjucks
@@ -45,7 +45,7 @@
     {% if not isStandardType(item.items) %}
       <p><strong>Items</strong>: {{ item.items.displayName }}</p>
 
-      {% if b.items.properties or b.items.examples.length %}
+      {% if item.items.properties or item.items.examples.length %}
         <div class="items">
           {% if item.items.properties %}
             <ul>


### PR DESCRIPTION
Fix item rendering so properties are displayed along with the type display name.