### PR TITLE
Fix generic error type

### DIFF
--- a/examples/array-generic.raml
+++ b/examples/array-generic.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: API used to test broken features
+version: v1
+baseUri: http://api.samplehost.com/broken/{version}
+mediaType: application/json
+protocols: [HTTP, HTTPS]
+
+/:
+  get:
+    responses:
+      200:
+        body:
+          type: array
+          example: ["somevalue","anothervalue"]

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -165,7 +165,7 @@
 
                         {% if b.type %}
                           {% if isStandardType(b.type) %}
-                            {% if b.type === 'array' %}
+                            {% if b.type === 'array' and b.items %}
                               <p><strong>Type</strong>: array of {% if isStandardType(b.items) %}{{ b.items }}{% else %}{{ b.items.displayName }}{% endif %}</p>
                             {% else %}
                               <p><strong>Type</strong>: {{ b.type }}</p>
@@ -260,7 +260,7 @@
 
                           {% if b.type %}
                             {% if isStandardType(b.type) %}
-                              {% if b.type === 'array' %}
+                              {% if b.type === 'array' and b.items %}
                                 <p><strong>Type</strong>: array of {% if isStandardType(b.items) %}{{ b.items }}{% else %}{{ b.items.displayName }}{% endif %}</p>
                               {% else %}
                                 <p><strong>Type</strong>: {{ b.type }}</p>


### PR DESCRIPTION
Hi 😃 

Sadly, it looks like 4.0.0-beta15 (or slightly earlier) introduced a small regression when it comes to rendering [generic arrays](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#array-type): Having something like `type: array` inside a response or request body specification resulted in a generic template render error. 

This patch should solve this by requiring also the items property being filled before iterating over it.