### PR TITLE
Complement missing security scheme data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+4.0.6 - January 23, 2017
+- Fixed template render error (#305)
+
 4.0.5 - January 9, 2017
 - Fix array examples (#302)
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function render(source, config) {
       if (typeof type === 'object') {
         return false;
       }
-      return type.indexOf('{') === -1 && type.indexOf('<') === -1;
+      return type && type.indexOf('{') === -1 && type.indexOf('<') === -1;
     };
 
     if (config.processRamlObj) {

--- a/index.js
+++ b/index.js
@@ -76,12 +76,23 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       markdown.register(env, md => marked(md, { renderer }));
 
+      const resolveSecuritySchemeName = ( name ) => {
+        if( ramlObj.securitySchemes && ramlObj.securitySchemes[name] ) {
+          const scheme = ramlObj.securitySchemes[name]
+
+          if( scheme.displayName ) {
+            return scheme.displayName
+          }
+        }
+        return name
+      }
+
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
         let out = '';
         if (typeof securedBy === 'object') {
           Object.keys(securedBy).forEach((key) => {
-            out += `<b>${key}</b>`;
+            out += `<b>${resolveSecuritySchemeName( key )}</b>`;
 
             if (securedBy[key].scopes.length) {
               out += ' with scopes:<ul>';
@@ -94,7 +105,7 @@ function getDefaultConfig(mainTemplate, templatesPath) {
             }
           });
         } else {
-          out = `<b>${securedBy}</b>`;
+          out = `<b>${resolveSecuritySchemeName(securedBy)}</b>`;
         }
         return out;
       };

--- a/index.js
+++ b/index.js
@@ -76,23 +76,23 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       markdown.register(env, md => marked(md, { renderer }));
 
-      const resolveSecuritySchemeName = ( name ) => {
-        if( ramlObj.securitySchemes && ramlObj.securitySchemes[name] ) {
-          const scheme = ramlObj.securitySchemes[name]
+      const resolveSecuritySchemeName = (name) => {
+        if (ramlObj.securitySchemes && ramlObj.securitySchemes[name]) {
+          const scheme = ramlObj.securitySchemes[name];
 
-          if( scheme.displayName ) {
-            return scheme.displayName
+          if (scheme.displayName) {
+            return scheme.displayName;
           }
         }
-        return name
-      }
+        return name;
+      };
 
       // Parse securedBy and use scopes if they are defined
       ramlObj.renderSecuredBy = function (securedBy) {
         let out = '';
         if (typeof securedBy === 'object') {
           Object.keys(securedBy).forEach((key) => {
-            out += `<b>${resolveSecuritySchemeName( key )}</b>`;
+            out += `<b>${resolveSecuritySchemeName(key)}</b>`;
 
             if (securedBy[key].scopes.length) {
               out += ' with scopes:<ul>';

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -341,6 +341,15 @@
                         </ul>
                       {% endif %}
 
+                      {% if securityScheme.describedBy.queryParameters.length %}
+                        <h3>Query Parameters</h3>
+                        <ul>
+                          {% for item in securityScheme.describedBy.queryParameters %}
+                            {% include "./item.nunjucks" %}
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+
                       {% for response in securityScheme.describedBy.responses.length %}
                         <h2>HTTP status code <a href="http://httpstatus.es/{{ response.code }}" target="_blank">{{ response.code }}</a></h2>
 {% markdown %}

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -330,7 +330,7 @@
                   <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
                     {% for securedBy in method.securedBy %}
                       {% set securityScheme = securitySchemes[securedBy] %}
-                      <h1>Secured by {{ securedBy }}</h1>
+                      <h1>Secured by {% if securityScheme.displayName %}{{ securityScheme.displayName }}{% else %}{{ securedBy }}{% endif %}</h1>
 
                       {% if securityScheme.describedBy.headers.length %}
                         <h3>Headers</h3>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml2html",
   "description": "RAML to HTML documentation generator",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": {
     "name": "Kevin Renskers",
     "email": "info@mixedcase.nl"


### PR DESCRIPTION
This fix adds query parameters to security tab in method views plus uses the displayName of securitySchemes instead of RAML document reference names.(like oauth_2_0)