### PR TITLE
Change the way security schemes are rendered to a more consistent way.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,38 +76,11 @@ function getDefaultConfig(mainTemplate, templatesPath) {
 
       markdown.register(env, md => marked(md, { renderer }));
 
-      const resolveSecuritySchemeName = (name) => {
-        if (ramlObj.securitySchemes && ramlObj.securitySchemes[name]) {
-          const scheme = ramlObj.securitySchemes[name];
-
-          if (scheme.displayName) {
-            return scheme.displayName;
-          }
-        }
-        return name;
-      };
-
-      // Parse securedBy and use scopes if they are defined
-      ramlObj.renderSecuredBy = function (securedBy) {
-        let out = '';
+      ramlObj.getSecuritySchemeName = function (securedBy) {
         if (typeof securedBy === 'object') {
-          Object.keys(securedBy).forEach((key) => {
-            out += `<b>${resolveSecuritySchemeName(key)}</b>`;
-
-            if (securedBy[key].scopes.length) {
-              out += ' with scopes:<ul>';
-
-              securedBy[key].scopes.forEach((scope) => {
-                out += `<li>${scope}</li>`;
-              });
-
-              out += '</ul>';
-            }
-          });
-        } else {
-          out = `<b>${resolveSecuritySchemeName(securedBy)}</b>`;
+          return Object.keys(securedBy)[0];
         }
-        return out;
+        return securedBy;
       };
 
       // Render the main template using the raml object and fix the double quotes

--- a/lib/resource.nunjucks
+++ b/lib/resource.nunjucks
@@ -69,9 +69,18 @@
                 {% for securedBy in method.securedBy %}
                   {% if securedBy %}
                     <div class="alert alert-warning">
-                      {% set securedByScopes = renderSecuredBy(securedBy) %}
-                      <span class="glyphicon glyphicon-lock" title="Authentication required"></span> Secured by {{ securedByScopes }}
-                      {% set securityScheme = securitySchemes[securedBy] %}
+                      {% set securitySchemeName = getSecuritySchemeName(securedBy) %}
+                      {% set securityScheme = securitySchemes[securitySchemeName] %}
+                      <span class="glyphicon glyphicon-lock" title="Authentication required"></span>
+                      Secured by <b>{% if securityScheme.displayName %}{{securityScheme.displayName}}{% else %}{{securitySchemeName}}{% endif %}</b>
+                      {% if securedBy[securitySchemeName].scopes %}
+                        with scopes:
+                        <ul>
+                          {% for scope in securedBy[securitySchemeName].scopes %}
+                            <li>{{scope}}</li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
                       {% if securityScheme.description %}
 {% markdown %}
 {{ securityScheme.description }}
@@ -329,7 +338,8 @@
                 {% if method.securedBy.length %}
                   <div class="tab-pane" id="{{ resource.uniqueId }}_{{ method.method }}_securedby">
                     {% for securedBy in method.securedBy %}
-                      {% set securityScheme = securitySchemes[securedBy] %}
+                      {% set securitySchemeName = getSecuritySchemeName(securedBy) %}
+                      {% set securityScheme = securitySchemes[securitySchemeName] %}
                       <h1>Secured by {% if securityScheme.displayName %}{{ securityScheme.displayName }}{% else %}{{ securedBy }}{% endif %}</h1>
 
                       {% if securityScheme.describedBy.headers.length %}


### PR DESCRIPTION
Introduces a new render helper function: getSecuritySchemeName and moves the logic of renderSecuredBy to the templates.