### PR TITLE
Support arbitrary CLI options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,22 @@
 module.exports = {
-  extends: 'loopwerk',
+  extends: [
+    'eslint:recommended',
+    'prettier',
+  ],
+  plugins: [
+    'prettier',
+  ],
   env: {
+    es6: true,
     browser: false,
-    node: true
+    node: true,
+    commonjs: true,
+  },
+  parserOptions: {
+    ecmaVersion: 7,
   },
   rules: {
-    'func-names': 0,
-    'no-param-reassign': 0,
-    'max-len': 0,
-    'prefer-spread': 0,
-    'global-require': 0,
+    'prettier/prettier': ['error', {trailingComma: 'es5', singleQuote: true}],
+    'no-console': 'off',
   }
 };

--- a/bin/raml2html
+++ b/bin/raml2html
@@ -24,9 +24,12 @@ const argv = yargs
   .describe('t', 'Template path')
   .describe('theme', 'Theme name')
   .example('raml2html example.raml > example.html')
-  .example('raml2html --theme raml2html-markdown-theme example.raml > example.html')
-  .example('raml2html --template my-template.nunjucks -i example.raml -o example.html')
-  .argv;
+  .example(
+    'raml2html --theme raml2html-markdown-theme example.raml > example.html'
+  )
+  .example(
+    'raml2html --template my-template.nunjucks -i example.raml -o example.html'
+  ).argv;
 
 let input = argv.input;
 
@@ -48,21 +51,24 @@ if (argv.template) {
 }
 
 // Start the rendering process
-raml2html.render(input, config).then((result) => {
-  if (argv.output) {
-    fs.writeFileSync(argv.output, result);
-  } else {
-    // Simply output to console
-    process.stdout.write(result, () => {
-      process.exit(0);
-    });
-  }
-}).catch((error) => {
-  if (error.message) {
-    console.error(error.message);
-  }
-  if (error.parserErrors) {
-    console.error(JSON.stringify(error.parserErrors, null, 2));
-  }
-  process.exit(1);
-});
+raml2html
+  .render(input, config)
+  .then(result => {
+    if (argv.output) {
+      fs.writeFileSync(argv.output, result);
+    } else {
+      // Simply output to console
+      process.stdout.write(result, () => {
+        process.exit(0);
+      });
+    }
+  })
+  .catch(error => {
+    if (error.message) {
+      console.error(error.message);
+    }
+    if (error.parserErrors) {
+      console.error(JSON.stringify(error.parserErrors, null, 2));
+    }
+    process.exit(1);
+  });

--- a/bin/raml2html
+++ b/bin/raml2html
@@ -2,43 +2,55 @@
 
 'use strict';
 
-const program = require('commander');
+const yargs = require('yargs');
 const fs = require('fs');
 const raml2html = require('..');
 const pjson = require('../package.json');
 
-program
+const argv = yargs
+  .usage('Usage: raml2html [options] [RAML input file]')
   .version(pjson.version)
-  .usage('[options] [RAML input file]')
-  .option('-i, --input [input]', 'RAML input file')
-  .option('--theme [theme]', 'Name of a raml2html theme')
-  .option('-t, --template [template]', 'Filename of the custom Nunjucks template')
-  .option('-o, --output [output]', 'HTML output file')
-  .parse(process.argv);
+  .alias('i', 'input')
+  .alias('o', 'output')
+  .alias('t', 'template')
+  .alias('h', 'help')
+  .help('h')
+  .string('i')
+  .string('o')
+  .string('t')
+  .string('theme')
+  .describe('i', 'Input file')
+  .describe('o', 'Output file')
+  .describe('t', 'Template path')
+  .describe('theme', 'Theme name')
+  .example('raml2html example.raml > example.html')
+  .example('raml2html --theme raml2html-markdown-theme example.raml > example.html')
+  .example('raml2html --template my-template.nunjucks -i example.raml -o example.html')
+  .argv;
 
-let input = program.input;
+let input = argv.input;
 
 if (!input) {
-  if (program.args.length !== 1) {
-    console.error('Error: You need to specify the RAML input file');
-    program.help();
+  if (argv._.length !== 1) {
+    console.error('Error: You need to specify the RAML input file\n');
+    yargs.showHelp();
     process.exit(1);
   }
 
-  input = program.args[0];
+  input = argv._[0];
 }
 
 let config;
-if (program.template) {
-  config = raml2html.getConfigForTemplate(program.template);
+if (argv.template) {
+  config = raml2html.getConfigForTemplate(argv.template);
 } else {
-  config = raml2html.getConfigForTheme(program.theme);
+  config = raml2html.getConfigForTheme(argv.theme, argv);
 }
 
 // Start the rendering process
 raml2html.render(input, config).then((result) => {
-  if (program.output) {
-    fs.writeFileSync(program.output, result);
+  if (argv.output) {
+    fs.writeFileSync(argv.output, result);
   } else {
     // Simply output to console
     process.stdout.write(result, () => {

--- a/examples/script.js
+++ b/examples/script.js
@@ -19,22 +19,31 @@ const ramlFile = path.join(__dirname, 'helloworld.raml');
  */
 const config1 = raml2html.getDefaultConfig();
 
-raml2html.render(ramlFile, config1).then((result) => {
-  console.log('1: ', result.length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, config1).then(
+  result => {
+    console.log('1: ', result.length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);
 
 /**
  * Using your own templates using the default processRamlObj function.
  */
-const config2 = raml2html.getDefaultConfig('./custom-template-test/template.nunjucks', __dirname);
+const config2 = raml2html.getDefaultConfig(
+  './custom-template-test/template.nunjucks',
+  __dirname
+);
 
-raml2html.render(ramlFile, config2).then((result) => {
-  console.log('2: ', result.trim().length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, config2).then(
+  result => {
+    console.log('2: ', result.trim().length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);
 
 /**
  * If you want to customize everything, just create the config object yourself from scratch.
@@ -44,7 +53,7 @@ raml2html.render(ramlFile, config2).then((result) => {
  */
 const config3 = {
   processRamlObj() {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       resolve('<h1>\n\n\n<!--This is a test-->Hi!</h1>');
     });
   },
@@ -52,55 +61,67 @@ const config3 = {
   postProcessHtml: config1.postProcessHtml,
 };
 
-raml2html.render(ramlFile, config3).then((result) => {
-  console.log('3: ', result.length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, config3).then(
+  result => {
+    console.log('3: ', result.length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);
 
 /**
  * You can also customize the postProcessHtml function.
  */
 const config4 = {
   processRamlObj() {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       resolve('<h1>Hi!</h1>');
     });
   },
 
   postProcessHtml() {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       resolve('ABC');
     });
   },
 };
 
-raml2html.render(ramlFile, config4).then((result) => {
-  console.log('4: ', result.length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, config4).then(
+  result => {
+    console.log('4: ', result.length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);
 
 /**
  * Testing if it works with no config at all. It outputs a JSON version of the RAML file.
  */
-raml2html.render(ramlFile, {}).then((result) => {
-  console.log('5: ', Object.keys(result).length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, {}).then(
+  result => {
+    console.log('5: ', Object.keys(result).length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);
 
 /**
  * If you want to only customize the Nunjucks configuration, just add a setupNunjucks function to the default config.
  */
 const config6 = raml2html.getDefaultConfig();
-config6.setupNunjucks = function (env) {
+config6.setupNunjucks = function(env) {
   // Do stuff with env here
   env.bla = 'bla';
 };
 
-raml2html.render(ramlFile, config6).then((result) => {
-  console.log('6: ', result.length);
-}, (error) => {
-  console.log('error! ', error);
-});
+raml2html.render(ramlFile, config6).then(
+  result => {
+    console.log('6: ', result.length);
+  },
+  error => {
+    console.log('error! ', error);
+  }
+);

--- a/index.js
+++ b/index.js
@@ -23,11 +23,11 @@ function render(source, config) {
   config = config || {};
   config.raml2HtmlVersion = pjson.version;
 
-  return raml2obj.parse(source).then((ramlObj) => {
+  return raml2obj.parse(source).then(ramlObj => {
     ramlObj.config = config;
 
     if (config.processRamlObj) {
-      return config.processRamlObj(ramlObj, config).then((html) => {
+      return config.processRamlObj(ramlObj, config).then(html => {
         if (config.postProcessHtml) {
           return config.postProcessHtml(html);
         }
@@ -48,7 +48,7 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
   return {
     processRamlObj(ramlObj, config) {
       const renderer = new marked.Renderer();
-      renderer.table = function (thead, tbody) {
+      renderer.table = function(thead, tbody) {
         // Render Bootstrap style tables
         return `<table class="table"><thead>${thead}</thead><tbody>${tbody}</tbody></table>`;
       };
@@ -62,14 +62,14 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
 
       markdown.register(env, md => marked(md, { renderer }));
 
-      ramlObj.isStandardType = function (type) {
+      ramlObj.isStandardType = function(type) {
         if (typeof type === 'object') {
           return false;
         }
         return type && type.indexOf('{') === -1 && type.indexOf('<') === -1;
       };
 
-      const resolveSecuritySchemeName = (name) => {
+      const resolveSecuritySchemeName = name => {
         if (ramlObj.securitySchemes && ramlObj.securitySchemes[name]) {
           const scheme = ramlObj.securitySchemes[name];
 
@@ -81,16 +81,16 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
       };
 
       // Parse securedBy and use scopes if they are defined
-      ramlObj.renderSecuredBy = function (securedBy) {
+      ramlObj.renderSecuredBy = function(securedBy) {
         let out = '';
         if (typeof securedBy === 'object') {
-          Object.keys(securedBy).forEach((key) => {
+          Object.keys(securedBy).forEach(key => {
             out += `<b>${resolveSecuritySchemeName(key)}</b>`;
 
             if (securedBy[key].scopes.length) {
               out += ' with scopes:<ul>';
 
-              securedBy[key].scopes.forEach((scope) => {
+              securedBy[key].scopes.forEach(scope => {
                 out += `<li>${scope}</li>`;
               });
 
@@ -108,7 +108,7 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
       html = html.replace(/&quot;/g, '"');
 
       // Return the promise with the html
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         resolve(html);
       });
     },
@@ -153,7 +153,9 @@ function getConfigForTheme(theme, programArguments) {
     return config;
   } catch (err) {
     // Nope, forward to getConfigForTemplate
-    const templatesPath = path.dirname(require.resolve(`${theme}/package.json`));
+    const templatesPath = path.dirname(
+      require.resolve(`${theme}/package.json`)
+    );
     return getConfigForTemplate('index.nunjucks', templatesPath);
   }
 }
@@ -165,6 +167,8 @@ module.exports = {
 };
 
 if (require.main === module) {
-  console.error("This script is meant to be used as a library. You probably want to run bin/raml2html if you're looking for a CLI.");
+  console.error(
+    "This script is meant to be used as a library. You probably want to run bin/raml2html if you're looking for a CLI."
+  );
   process.exit(1);
 }

--- a/index.js
+++ b/index.js
@@ -132,16 +132,24 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
 
 /**
  * @param {String} [theme] - The name of a raml2html template, leave empty if you want to use the mainTemplate option
+ * @param {Object} [programArguments] - An object containing all program aruments
  * @returns {{processRamlObj: Function, postProcessHtml: Function}}
  */
-function getConfigForTheme(theme) {
+function getConfigForTheme(theme, programArguments) {
   if (!theme) {
     theme = 'raml2html-default-theme';
   }
 
   try {
-    // See if the theme supplies its own config object, and return it
+    // See if the theme supplies its own config object (or function that creates this object), and return it
     const config = require(theme);
+
+    // If it's a function then call it with the program arguments
+    if (typeof config === 'function') {
+      return config(programArguments);
+    }
+
+    // Otherwise we assume it's a config object (default behavior)
     return config;
   } catch (err) {
     // Nope, forward to getConfigForTemplate

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "url": "https://github.com/raml2html/raml2html/issues"
   },
   "dependencies": {
-    "commander": "2.9.x",
     "marked": "0.3.x",
     "minimize": "2.0.x",
     "nunjucks": "2.5.x",
     "nunjucks-markdown": "2.0.x",
+    "raml2html-default-theme": "1.x",
     "raml2obj": "4.1.x",
-    "raml2html-default-theme": "1.x"
+    "yargs": "7.0.x"
   },
   "devDependencies": {
     "eslint": "3.11.x",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "yargs": "7.0.x"
   },
   "devDependencies": {
-    "eslint": "3.11.x",
-    "eslint-config-loopwerk": "6.0.x",
-    "glob": "7.1.1"
+    "eslint": "3.14.x",
+    "eslint-config-prettier": "1.5.0",
+    "eslint-plugin-prettier": "2.0.1",
+    "glob": "7.1.1",
+    "prettier": "0.22.0"
   },
   "homepage": "https://github.com/raml2html/raml2html",
   "keywords": [
@@ -35,8 +37,7 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "lint": "eslint .",
-    "lintfix": "eslint . --fix"
+    "lint": "eslint . --fix"
   },
   "bin": {
     "raml2html": "./bin/raml2html"


### PR DESCRIPTION
Pass all CLI options (even ones we don't know about) to themes. They can use these for theme specific things like logo paths.

Needed for https://github.com/wdullaer/raml2slate/issues/3 for example.

Reason from switching away from Commander: https://github.com/tj/commander.js/issues/609