### PR TITLE
Update raml2obj dependency to 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you only want to configure the default Nunjucks environment you don't have to
 function. Just get the default config (`const config = raml2html.getDefaultConfig();`) and add a `setupNunjucks` function
 to it that takes `env` as its only parameter.
 
-See also `example/script.js` for an example of using raml2html as a library.
+See also `example/script.js` for multiple examples of using raml2html as a library.
 
 ### Gulp
 You can use the [raml2html directly from Gulp](https://gist.github.com/iki/784ddd5ab33c1e1b726b).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ raml2html is an open source project and your contribution is very much appreciat
 3. Add an example of the new feature to example.raml (if applicable)
 4. Send a pull request (with the **develop** branch as the target).
 
+To get the best environment to work on raml2html and the default theme, follow these steps.
+
+1. Checkout raml2html-default-theme's develop branch; `npm link`.
+2. Checkout raml2html's develop branch; first `npm link raml2html-default-theme` and then `npm link`.
+
+Now both projects are installed globally, but using the local development versions of both.
+From the theme repo's example folder you can run the `render-all-examples` script without problem.
+
 If your pull request is merged feel free to ask for push access. We want to get more maintainers! If you do
 have push access, please still work on feature branches and create pull requests, which then get reviewed.
 You can also review other people's pull requests and be involved in that way.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ raml2html.render(source, configWithDefaultTheme).then(function(result) {
  * object and must return a promise with the result. You can do whatever you want in this function.
  *
  * You can also supply a postProcessHtml function that can for example minify the generated HTML.
+ *
+ * You can also add a setupNunjucks function that takes the env as its only parameter.
  */
 raml2html.render(source, config).then(function(result) {
   // Save the result to a file or do something else with the result
@@ -68,10 +70,6 @@ raml2html.render(source, config).then(function(result) {
   // Output error
 });
 ```
-
-If you only want to configure the default Nunjucks environment you don't have to override the entire `processRamlObj`
-function. Just get the default config (`const config = raml2html.getDefaultConfig();`) and add a `setupNunjucks` function
-to it that takes `env` as its only parameter.
 
 See also `example/script.js` for multiple examples of using raml2html as a library.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please see the following links for live examples:
 
 ## Before you report a bug
 If you get parsing errors, please do not report them to raml2html: it doesn't do the actual RAML parsing.
-Review the error and fix your RAML file, or open a new issue at [raml-js-parser](https://github.com/raml-org/raml-js-parser-2).
+Review the error and fix your RAML file, or open a new issue at [raml-js-parser-2](https://github.com/raml-org/raml-js-parser-2).
 
 
 ## Contributing

--- a/examples/script.js
+++ b/examples/script.js
@@ -17,7 +17,7 @@ const ramlFile = path.join(__dirname, 'helloworld.raml');
  * raml2html.render() needs a config object with at least a `processRamlObj` property.
  * Instead of creating this config object ourselves, we can just ask for raml2html.getDefaultConfig():
  */
-const config1 = raml2html.getDefaultConfig();
+const config1 = raml2html.getConfigForTheme('raml2html-default-theme');
 
 raml2html.render(ramlFile, config1).then(
   result => {
@@ -31,7 +31,7 @@ raml2html.render(ramlFile, config1).then(
 /**
  * Using your own templates using the default processRamlObj function.
  */
-const config2 = raml2html.getDefaultConfig(
+const config2 = raml2html.getConfigForTemplate(
   './custom-template-test/template.nunjucks',
   __dirname
 );
@@ -111,7 +111,7 @@ raml2html.render(ramlFile, {}).then(
 /**
  * If you want to only customize the Nunjucks configuration, just add a setupNunjucks function to the default config.
  */
-const config6 = raml2html.getDefaultConfig();
+const config6 = raml2html.getConfigForTheme('raml2html-default-theme');
 config6.setupNunjucks = function(env) {
   // Do stuff with env here
   env.bla = 'bla';

--- a/index.js
+++ b/index.js
@@ -69,40 +69,6 @@ function getConfigForTemplate(mainTemplate, templatesPath) {
         return type && type.indexOf('{') === -1 && type.indexOf('<') === -1;
       };
 
-      const resolveSecuritySchemeName = name => {
-        if (ramlObj.securitySchemes && ramlObj.securitySchemes[name]) {
-          const scheme = ramlObj.securitySchemes[name];
-
-          if (scheme.displayName) {
-            return scheme.displayName;
-          }
-        }
-        return name;
-      };
-
-      // Parse securedBy and use scopes if they are defined
-      ramlObj.renderSecuredBy = function(securedBy) {
-        let out = '';
-        if (typeof securedBy === 'object') {
-          Object.keys(securedBy).forEach(key => {
-            out += `<b>${resolveSecuritySchemeName(key)}</b>`;
-
-            if (securedBy[key].scopes.length) {
-              out += ' with scopes:<ul>';
-
-              securedBy[key].scopes.forEach(scope => {
-                out += `<li>${scope}</li>`;
-              });
-
-              out += '</ul>';
-            }
-          });
-        } else {
-          out = `<b>${resolveSecuritySchemeName(securedBy)}</b>`;
-        }
-        return out;
-      };
-
       // Render the main template using the raml object and fix the double quotes
       let html = env.render(mainTemplate, ramlObj);
       html = html.replace(/&quot;/g, '"');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml2html",
   "description": "RAML to HTML documentation generator",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "Kevin Renskers",
     "email": "kevin@mixedcase.nl"
@@ -14,8 +14,8 @@
     "minimize": "2.0.x",
     "nunjucks": "2.5.x",
     "nunjucks-markdown": "2.0.x",
-    "raml2html-default-theme": "1.x",
-    "raml2obj": "4.1.x",
+    "raml2html-default-theme": "2.x",
+    "raml2obj": "5.1.x",
     "yargs": "7.0.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "eslint": "3.14.x",
     "eslint-plugin-prettier": "2.0.x",
-    "glob": "7.1.x",
     "prettier": "0.22.x"
   },
   "homepage": "https://github.com/raml2html/raml2html",


### PR DESCRIPTION
Use new raml2obj and new default theme. Update versions, and remove now unused code.

Closes #330.