### PR TITLE
IE11 problem opening modal a second time

### DIFF
--- a/lib/template.nunjucks
+++ b/lib/template.nunjucks
@@ -27,8 +27,7 @@
 
         // open modal on hashes like #_action_get
         $(window).bind('hashchange', function(e) {
-          var anchor_id = document.location.hash.substr(1); //strip #
-          var element = $('#' + anchor_id);
+          var element = $(document.location.hash);
 
           // do we have such element + is it a modal?  --> show it
           if (element.length && element.hasClass('modal')) {
@@ -44,6 +43,7 @@
           try {
             if (history && history.replaceState) {
                 history.replaceState({}, '', '#');
+                window.location.href = '#';
             }
           } catch(e) {}
         });


### PR DESCRIPTION
Hi,

I have seen there is a problem when you try to open the same method modal view for a second time in a row. Apparently the 'hashchange' event is not received by the bind method. By this reason I have decided to set the window.location.href to the root url when the user hides the modal dialog. I don't know if the solution is the best, but it has worked for me.

Besides, I think the 'var anchor_id' is not needed in the 'hashchange' bind.

Regards