### PR TITLE
postprocessing: add a pretty option

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -13,6 +13,7 @@ const argv = yargs
   .alias('i', 'input')
   .alias('o', 'output')
   .alias('t', 'template')
+  .alias('p', 'pretty')
   .alias('v', 'validate')
   .alias('h', 'help')
   .help('h')
@@ -21,10 +22,12 @@ const argv = yargs
   .string('t')
   .string('theme')
   .boolean('v')
+  .boolean('p')
   .describe('i', 'Input file')
   .describe('o', 'Output file')
   .describe('t', 'Template path')
   .describe('v', 'Validate RAML and examples (off by default)')
+  .describe('p', 'Make the output file pretty (readable)')
   .describe('theme', 'Theme name')
   .example('raml2html example.raml > example.html')
   .example(
@@ -55,7 +58,7 @@ if (argv.template) {
 
 // Start the rendering process
 raml2html
-  .render(input, config, argv.validate)
+  .render(input, config, argv)
   .then(result => {
     if (argv.output) {
       fs.writeFileSync(argv.output, result);

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ function render(source, config, options) {
   config = config || {};
   config.raml2HtmlVersion = pjson.version;
 
+  // Check if option is `validation` to keep backward compatibility
+  if (typeof options === 'boolean') {
+    options = {validate: options};
+  }
+
   return raml2obj.parse(source, options.validate).then(ramlObj => {
     ramlObj.config = config;
 


### PR DESCRIPTION
Add a pretty option to skip minimizing the output during the post processing.

The use case that I have for that is that in a project that I am working on, we keep the output html file in the git repo so that we can have a reference to the api using something like rawgit.

The problem is if the api changes in anyway, the output file gets changed almost completely, and the diff in github is always not shown. So this commit can decrease the number of the changed lines, making things better.

The option is backward compatible so that things should work as expected if used the same way as before. Only if `--pretty (-p)` option is used it will not minimize the output.