### PR TITLE
allow themes to copy assets to the output directory

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -2,8 +2,8 @@
 
 'use strict';
 
-const yargs = require('yargs');
 const fs = require('fs');
+const yargs = require('yargs');
 const raml2html = require('..');
 const pjson = require('../package.json');
 
@@ -56,19 +56,31 @@ if (argv.template) {
   config = raml2html.getConfigForTheme(argv.theme, argv);
 }
 
+function writeOutput(result, config, argv) {
+  return new Promise((resolve, reject) => {
+    if (argv.output) {
+      fs.writeFile(argv.output, result, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    } else {
+      // Simply output to console
+      process.stdout.write(result);
+      resolve();
+    }
+  });
+}
+
 // Start the rendering process
 raml2html
   .render(input, config, argv)
   .then(result => {
-    if (argv.output) {
-      fs.writeFileSync(argv.output, result);
-    } else {
-      // Simply output to console
-      process.stdout.write(result, () => {
-        process.exit(0);
-      });
-    }
+    return (config.writeOutput || writeOutput)(result, config, argv);
   })
+  .then(() => process.exit(0))
   .catch(error => {
     if (error.message) {
       console.error(error.message);


### PR DESCRIPTION
Hey,

this PR adds support for themes to add their own assets to the output directory of the html file. The primary reason for adding this feature is that I need a theme that bundles its assets in order to provide api documentation on local networks that don’t have access to the internet.

Themes may define a `copyAssets` method as part of their config. If they do the function will receive the target directory of the output file as their only argument and should return a Promise to indicate completion. I thought about adding some logic to handle things like strings as arguments for the `copyAssets` config option, but that is likely to fall short in terms of what people might want to do with this. The theme should know best how to handle its assets.

I wasn’t quite sure where to add the documentation for this. If there is a theme guide somewhere I'll be happy to submit a pull request.

Thank you for your time and your work you put into this project!