### PR TITLE
Output errors with trace

### DIFF
--- a/bin/raml2html
+++ b/bin/raml2html
@@ -97,17 +97,27 @@ function errorMessage(error) {
   return `${error.code}: ${error.message}`;
 }
 
-function writeParserErrors(parserErrors) {
-  parserErrors.forEach(error => {
-    let message = `[${errorPath(error)}] ${errorMessage(error)}`;
+function errorStackTrace(error, nocolor) {
+  let message = `${errorPath(error)}: ${errorMessage(error)}`;
 
+  if (!nocolor) {
     if (error.isWarning) {
       message = chalk.yellow(message);
     } else {
       message = chalk.red(message);
     }
+  }
 
-    console.error(message);
+  if (error.trace) {
+    message += '\n  ' + errorStackTrace(error.trace[0], true);
+  }
+
+  return message;
+}
+
+function writeParserErrors(parserErrors) {
+  parserErrors.forEach(error => {
+    console.error(errorStackTrace(error));
   });
 }
 

--- a/bin/raml2html
+++ b/bin/raml2html
@@ -98,7 +98,7 @@ function errorMessage(error) {
 }
 
 function errorStackTrace(error, nocolor) {
-  let message = `${errorPath(error)}: ${errorMessage(error)}`;
+  let message = `${errorMessage(error)} (${errorPath(error)})`;
 
   if (!nocolor) {
     if (error.isWarning) {


### PR DESCRIPTION
As I menthioned https://github.com/raml2html/raml2html/pull/395#discussion_r216311980 if we print `error` itself we don't have enough information. We should use `trace` to get more information about problem.

Output preview:
![image](https://user-images.githubusercontent.com/874159/45372217-1775a100-b5f5-11e8-9dc6-d7187ec742e0.png)

