### PR TITLE
Add support to RAML parser resolvers options

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ function render(source, config, options) {
     .parse(source, {
       validate: options.validate,
       extensionsAndOverlays: options.extensionsAndOverlays,
+      httpResolver: options.httpResolver,
+      fsResolver: options.fsResolver,
     })
     .then(ramlObj => {
       if (config.processRamlObj) {


### PR DESCRIPTION
Requires [raml2obj#59](https://github.com/raml2html/raml2obj/pull/59) to be merged.

Fix #394