### PR TITLE
AddUniqueNr filter for raml2html/default-theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const raml2obj = require('raml2obj');
 const pjson = require('./package.json');
 const nunjucks = require('nunjucks');
 const markdown = require('nunjucks-markdown');
-const njIncludeData = require('nunjucks-includeData');
 const marked = require('marked');
 const Minimize = require('minimize');
 const pretty = require('pretty');
@@ -91,7 +90,6 @@ function getConfigForTemplate(mainTemplate) {
         config.setupNunjucks(env);
       }
 
-      njIncludeData.install(env); // Init the extension with the nunjucks environment
       markdown.register(env, md => marked(md, { renderer }));
 
       ramlObj.isStandardType = function(type) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
-
 const raml2obj = require('raml2obj');
 const pjson = require('./package.json');
 const nunjucks = require('nunjucks');
 const markdown = require('nunjucks-markdown');
+const njIncludeData = require('nunjucks-includeData');
 const marked = require('marked');
 const Minimize = require('minimize');
 const pretty = require('pretty');
@@ -81,12 +81,17 @@ function getConfigForTemplate(mainTemplate) {
       };
 
       // Setup the Nunjucks environment with the markdown parser
-      const env = nunjucks.configure(templatesPath, { autoescape: false });
+      var env = nunjucks.configure(templatesPath, { autoescape: false });
+
+      env.addFilter('addUniqueNr', function(name) {
+        return name + '-' + Date.now() + '-' + Math.random().toString(36).substr(2);
+        });
 
       if (config.setupNunjucks) {
         config.setupNunjucks(env);
       }
 
+      njIncludeData.install(env); // Init the extension with the nunjucks environment
       markdown.register(env, md => marked(md, { renderer }));
 
       ramlObj.isStandardType = function(type) {


### PR DESCRIPTION
The addUniqueNr filter is for generating unique id's to each expandable object/array panel. Since an object/array can appear more than once in the same window it is not safe to use only the object's or array's name as id.

Changes made related to PR Clickable objects and arrays https://github.com/raml2html/default-theme/pull/31